### PR TITLE
Improve pitch detection in noisy environments

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,8 @@
     let analyser;
     let dataArray;
     let running = false;
+    const RMS_THRESHOLD = 0.02;  // ignore quiet background noise
+    const EDGE_THRESHOLD = 0.1;  // find waveform edges more aggressively
     let startTime;
     let lastNote = null;
     let lastTime = 0;
@@ -114,9 +116,9 @@
             rms += val * val;
         }
         rms = Math.sqrt(rms / SIZE);
-        if (rms < 0.01) return -1;
+        if (rms < RMS_THRESHOLD) return -1;
 
-        let r1 = 0, r2 = SIZE - 1, thres = 0.2;
+        let r1 = 0, r2 = SIZE - 1, thres = EDGE_THRESHOLD;
         for (let i = 0; i < SIZE / 2; i++) if (Math.abs(buf[i]) < thres) { r1 = i; break; }
         for (let i = 1; i < SIZE / 2; i++) if (Math.abs(buf[SIZE - i]) < thres) { r2 = SIZE - i; break; }
         buf = buf.slice(r1, r2);

--- a/webapp.py
+++ b/webapp.py
@@ -17,7 +17,7 @@ def freq_to_note(freq):
     return f"{note_names[note_num % 12]}{octave}"
 
 
-def detect_pitches(samples, samplerate, hop_size=512):
+def detect_pitches(samples, samplerate, hop_size=512, noise_floor=0.02):
     tolerance = 0.8
     win_s = 1024
     pitch_o = aubio.pitch('default', win_s, hop_size, samplerate)
@@ -31,7 +31,10 @@ def detect_pitches(samples, samplerate, hop_size=512):
         block = samples[i:i + hop_size]
         if len(block) < hop_size:
             block = np.pad(block, (0, hop_size - len(block)))
+        rms = np.sqrt(np.mean(block ** 2))
         pitch = float(pitch_o(block)[0])
+        if rms < noise_floor:
+            pitch = 0.0
         pitches.append(pitch)
         timestamps.append(i / float(samplerate))
 


### PR DESCRIPTION
## Summary
- tweak webapp's JS pitch detector to ignore quiet noise
- gate frequencies on the server side using RMS amplitude

## Testing
- `python3 -m py_compile pitch_detector.py webapp.py`

------
https://chatgpt.com/codex/tasks/task_e_6843a198076883258950f4554836e5b7